### PR TITLE
[Fix] Multiple throttlers actives at the same time

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -74,26 +74,6 @@ import configuration from './config/configuration';
             ttl: parseInt(configService.get('THROTTLE_TTL') || '60') * 1000,
             limit: parseInt(configService.get('THROTTLE_LIMIT') || '500'),
           },
-          {
-            name: 'auth',
-            ttl:
-              parseInt(configService.get('THROTTLE_AUTH_TTL') || '900') * 1000,
-            limit: parseInt(configService.get('THROTTLE_AUTH_LIMIT') || '20'),
-          },
-          {
-            name: 'api',
-            ttl: parseInt(configService.get('THROTTLE_API_TTL') || '60') * 1000,
-            limit: parseInt(configService.get('THROTTLE_API_LIMIT') || '300'),
-          },
-          {
-            name: 'creation',
-            ttl:
-              parseInt(configService.get('THROTTLE_CREATION_TTL') || '60') *
-              1000,
-            limit: parseInt(
-              configService.get('THROTTLE_CREATION_LIMIT') || '100',
-            ),
-          },
         ];
       },
     }),


### PR DESCRIPTION
## Issue

After deploying japm to a server and configuring health checks we realize soon they were stop returning `200` and start returning `429`

The healthcheck, after 20 request, stops returning:

`{"status":"ok","info":{"prisma":{"status":"up"}},"error":{},"details":{"prisma":{"status":"up"}}}`

And starts returning

`{"statusCode":429,"message":"ThrottlerException: Too Many Requests"}`

---

We saw that the issue was that many throttlers where applying at the same time, being the `auth` the one with `20` max requests and triggering the `429` 

We can see that from the response headers that the endpoint returns: 
(note the `x-ratelimit-remaining-auth: 12`)

<img width="511" alt="image" src="https://github.com/user-attachments/assets/93020515-5695-4fc3-978c-f81aff4da131" />

----

After applying this PR we can see that effectlively we have only one rate limiter applying which is the default and `500req/60s` and it's correctly overwritten by the throttler health decorator with  `1000req/60s`

<img width="853" alt="image" src="https://github.com/user-attachments/assets/dd18886d-7646-47ac-96ae-44b52ee10dbb" />


