### PR TITLE
[Fix] Dockerfile dependant of local env

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -18,7 +18,7 @@ COPY package*.json ./
 RUN npm install
 # Copy Prisma schema and pre-generated client
 COPY prisma ./prisma/
-COPY node_modules/.prisma ./node_modules/.prisma
+RUN npx prisma generate
 
 # ---- Builder ----
 FROM dependencies AS builder


### PR DESCRIPTION
COPY files instead of generating the client makes the build dependant of your local env.

The dockerfile is expecting you having the dependencies installed in your local system, which in my opinion is wrong. I should not need to install dependencies locally in order to build the production dockerfile. Additionally in the future in the CI pipeline we would be having the same issue